### PR TITLE
Make recipe rating optional

### DIFF
--- a/src/components/__tests__/empty-cell.test.tsx
+++ b/src/components/__tests__/empty-cell.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { EmptyCell } from '../empty-cell'
+
+describe('EmptyCell', () => {
+  it('renders a dash', () => {
+    render(<EmptyCell />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('renders default sr-only label', () => {
+    render(<EmptyCell />)
+    expect(screen.getByText('None')).toBeInTheDocument()
+  })
+
+  it('accepts a custom label', () => {
+    render(<EmptyCell label="No rating" />)
+    expect(screen.getByText('No rating')).toBeInTheDocument()
+  })
+
+  it('accepts custom className', () => {
+    render(<EmptyCell className="custom-class" data-testid="empty-cell" />)
+    expect(screen.getByTestId('empty-cell')).toHaveClass('custom-class')
+  })
+})

--- a/src/components/empty-cell.tsx
+++ b/src/components/empty-cell.tsx
@@ -1,0 +1,15 @@
+import { cn } from '../helpers/dom'
+import { SrOnly } from './sr-only'
+
+export function EmptyCell({
+  label = 'None',
+  className,
+  ...props
+}: React.ComponentProps<'span'> & { label?: string }) {
+  return (
+    <span className={cn('text-slate-400 dark:text-zinc-500', className)} {...props}>
+      <span aria-hidden="true">&mdash;</span>
+      <SrOnly>{label}</SrOnly>
+    </span>
+  )
+}

--- a/src/routes/recipes/$category/$subcategory/$recipe/_private.edit.tsx
+++ b/src/routes/recipes/$category/$subcategory/$recipe/_private.edit.tsx
@@ -104,7 +104,7 @@ function RouteComponent() {
         title,
         source,
         category_id: Number(category_id),
-        rating: Number(rating),
+        rating: rating ? Number(rating) : null,
         subcategory_id: Number(subcategory_id),
         ingredients_md,
         directions_md,
@@ -234,7 +234,7 @@ function RouteComponent() {
                   <FormSelect
                     id="rating-select"
                     name="rating"
-                    defaultValue={recipe.rating}
+                    defaultValue={recipe.rating ?? ''}
                     disabled={updateReqStatus === 'loading'}
                   >
                     <option disabled value="">

--- a/src/routes/recipes/$category/$subcategory/$recipe/view.tsx
+++ b/src/routes/recipes/$category/$subcategory/$recipe/view.tsx
@@ -13,6 +13,7 @@ import { getDietaryPreferences } from '../../../../../api/dietary-preferences'
 import { DEVICE_CAN_SLEEP } from '../../../../../constants/device'
 import { title } from '../../../../../helpers/dom'
 import { Inline } from '../../../../../components/inline'
+import { EmptyCell } from '../../../../../components/empty-cell'
 import {
   PageActions,
   PageBackLink,
@@ -259,15 +260,19 @@ function RouteComponent() {
                     Rating
                   </div>
                   <div className="text-slate-600 dark:text-slate-400">
-                    <Inline spacing="xs">
-                      {[...new Array(recipe.rating)].map((_star, index) => (
-                        <Star
-                          key={`${recipe.id}-start-${index}`}
-                          size={16}
-                          className="text-yellow-500 fill-yellow-200"
-                        />
-                      ))}
-                    </Inline>
+                    {recipe.rating == null ? (
+                      <EmptyCell label="No rating" />
+                    ) : (
+                      <Inline spacing="xs">
+                        {[...new Array(recipe.rating)].map((_star, index) => (
+                          <Star
+                            key={`${recipe.id}-start-${index}`}
+                            size={16}
+                            className="text-yellow-500 fill-yellow-200"
+                          />
+                        ))}
+                      </Inline>
+                    )}
                   </div>
                 </Stack>
 

--- a/src/routes/recipes/$category/$subcategory/index.tsx
+++ b/src/routes/recipes/$category/$subcategory/index.tsx
@@ -12,6 +12,7 @@ import { PageHeader } from '../../../../components/page-header'
 import { PageHeading } from '../../../../components/page-heading'
 import { PageBackLink } from '../../../../components/page-actions'
 import { Inline } from '../../../../components/inline'
+import { EmptyCell } from '../../../../components/empty-cell'
 
 export const Route = createFileRoute('/recipes/$category/$subcategory/')({
   component: RouteComponent,
@@ -113,17 +114,23 @@ function RouteComponent() {
                       </td>
 
                       <td className="p-4 text-right">
-                        <span className="md:hidden">{recipe.rating}&nbsp;stars</span>
+                        {recipe.rating == null ? (
+                          <EmptyCell label="No rating" />
+                        ) : (
+                          <>
+                            <span className="md:hidden">{recipe.rating}&nbsp;stars</span>
 
-                        <Inline spacing="xs" className="hidden md:inline-flex">
-                          {[...new Array(recipe.rating)].map((_star, index) => (
-                            <Star
-                              key={`${recipe.id}-start-${index}`}
-                              size={16}
-                              className="text-yellow-500 fill-yellow-200"
-                            />
-                          ))}
-                        </Inline>
+                            <Inline spacing="xs" className="hidden md:inline-flex">
+                              {[...new Array(recipe.rating)].map((_star, index) => (
+                                <Star
+                                  key={`${recipe.id}-start-${index}`}
+                                  size={16}
+                                  className="text-yellow-500 fill-yellow-200"
+                                />
+                              ))}
+                            </Inline>
+                          </>
+                        )}
                       </td>
                     </tr>
                   )

--- a/src/routes/recipes/_private.add.tsx
+++ b/src/routes/recipes/_private.add.tsx
@@ -66,7 +66,7 @@ function RouteComponent() {
         slug: slugify(String(title)),
         source,
         category_id: Number(category_id),
-        rating: Number(rating),
+        rating: rating ? Number(rating) : null,
         subcategory_id: Number(subcategory_id),
         ingredients_md,
         directions_md,

--- a/src/routes/recipes/favorites.tsx
+++ b/src/routes/recipes/favorites.tsx
@@ -6,6 +6,7 @@ import { PageHeading } from '../../components/page-heading'
 import { PageBody } from '../../components/page-body'
 import { Inline } from '../../components/inline'
 import { RecipeTableSkeleton } from '../../components/recipe-table-skeleton'
+import { EmptyCell } from '../../components/empty-cell'
 import { title } from '../../helpers/dom'
 import { getRecipes } from '../../api/recipes'
 import { getCategories } from '../../api/categories'
@@ -148,17 +149,23 @@ function RouteComponent() {
                           </td>
 
                           <td className="p-4 text-right">
-                            <span className="md:hidden">{recipe.rating}&nbsp;stars</span>
+                            {recipe.rating == null ? (
+                              <EmptyCell label="No rating" />
+                            ) : (
+                              <>
+                                <span className="md:hidden">{recipe.rating}&nbsp;stars</span>
 
-                            <Inline spacing="xs" className="hidden md:inline-flex">
-                              {[...new Array(recipe.rating)].map((_star, index) => (
-                                <Star
-                                  key={`${recipe.id}-start-${index}`}
-                                  size={16}
-                                  className="text-yellow-500 fill-yellow-200"
-                                />
-                              ))}
-                            </Inline>
+                                <Inline spacing="xs" className="hidden md:inline-flex">
+                                  {[...new Array(recipe.rating)].map((_star, index) => (
+                                    <Star
+                                      key={`${recipe.id}-start-${index}`}
+                                      size={16}
+                                      className="text-yellow-500 fill-yellow-200"
+                                    />
+                                  ))}
+                                </Inline>
+                              </>
+                            )}
                           </td>
                         </tr>
                       )

--- a/src/routes/recipes/list.tsx
+++ b/src/routes/recipes/list.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from '../../components/page-header'
 import { PageHeading } from '../../components/page-heading'
 import { PageBody } from '../../components/page-body'
 import { RecipeTableSkeleton } from '../../components/recipe-table-skeleton'
+import { EmptyCell } from '../../components/empty-cell'
 import { getRecipes } from '../../api/recipes'
 import { getCategories } from '../../api/categories'
 import { getSubcategories } from '../../api/subcategories'
@@ -178,15 +179,19 @@ function RouteComponent() {
                               </td>
 
                               <td className="p-4">
-                                <Inline spacing="xs">
-                                  {[...new Array(recipe.rating)].map((_star, index) => (
-                                    <Star
-                                      key={`${recipe.id}-start-${index}`}
-                                      size={16}
-                                      className="text-yellow-500 fill-yellow-200"
-                                    />
-                                  ))}
-                                </Inline>
+                                {recipe.rating == null ? (
+                                  <EmptyCell label="No rating" />
+                                ) : (
+                                  <Inline spacing="xs">
+                                    {[...new Array(recipe.rating)].map((_star, index) => (
+                                      <Star
+                                        key={`${recipe.id}-start-${index}`}
+                                        size={16}
+                                        className="text-yellow-500 fill-yellow-200"
+                                      />
+                                    ))}
+                                  </Inline>
+                                )}
                               </td>
                             </tr>
                           )

--- a/src/types/recipes.ts
+++ b/src/types/recipes.ts
@@ -11,7 +11,7 @@ export const RecipeSchema = z.object({
   subcategory_id: z.number(),
   ingredients_md: z.string(),
   dietary_pref: z.array(z.string()),
-  rating: RecipeRatingSchema,
+  rating: RecipeRatingSchema.nullable(),
   directions_md: z.string(),
   slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
 })


### PR DESCRIPTION
## Summary
- The `rating` column already allowed `NULL` at the DB level, but the app's Zod schema required it, so submitting a recipe without selecting a rating threw a validation error.
- `rating` is now `.nullable()` in `RecipeSchema`; the add/edit forms submit `null` instead of `NaN` when no rating is chosen.
- Added an `EmptyCell` component (`src/components/empty-cell.tsx`) shown in place of the star rating wherever `recipe.rating` is `null` (list, favorites, category/subcategory index, and recipe detail views).

## Test plan
- [x] `npm run qa` (lint, type-check, tests, build) passes
- [ ] Manually add a recipe without selecting a rating and confirm it saves and displays the empty-cell placeholder
- [ ] Manually edit an existing recipe to clear its rating and confirm the same

Note: no tests were added yet for the route-level rendering logic or the schema/form changes — flagged as follow-up work.