### PR TITLE
Backfill JSDoc comments on global components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,11 +67,14 @@ This is a React-based family recipes app using:
 
 ### Coding preferences
 
+- Global components in `src/components/` should have a short JSDoc comment above the component
+  function describing its purpose (see `EmptyCell` for an example)
 - Prefer `type` over `interface` in TypeScript files
 - Run the `prettier` command against all files before finishing work
 - Place test files in `__tests__` directories (e.g., `src/components/__tests__/`,
   `src/helpers/__tests__/`)
-- Use `<Inline>` for horizontal wrapping layouts instead of raw `flex` divs; use `<Stack>` for vertical ones
+- Use `<Inline>` for horizontal wrapping layouts instead of raw `flex` divs; use `<Stack>` for
+  vertical ones
 
 ### Environment Setup
 

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -74,6 +74,7 @@ const buttonClasses = cva(
   },
 )
 
+/** Primary button with variant, size, and loading states */
 export function Button({
   className,
   variant = 'primary',

--- a/src/components/category-link.tsx
+++ b/src/components/category-link.tsx
@@ -1,6 +1,7 @@
 import { Link, type LinkProps } from '@tanstack/react-router'
 import { cn } from '../helpers/dom'
 
+/** Styled link card for a recipe category */
 export function CategoryLink({ className, ...props }: { className?: string } & LinkProps<'a'>) {
   return (
     <Link

--- a/src/components/category-skeleton.tsx
+++ b/src/components/category-skeleton.tsx
@@ -1,3 +1,4 @@
+/** Loading placeholder for a CategoryLink */
 export function CategoryLinkSkeleton() {
   return (
     <div className="h-42 w-full flex flex-col justify-center items-center bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 shadow-lg shadow-gray-100/50 dark:shadow-zinc-950/30 rounded-4xl animate-pulse">

--- a/src/components/dietary-preference-tag.tsx
+++ b/src/components/dietary-preference-tag.tsx
@@ -5,6 +5,7 @@ type DietaryPreferenceTagProps = {
   label: string
 }
 
+/** Small tag displaying a single dietary preference label */
 export function DietaryPreferenceTag({ label }: DietaryPreferenceTagProps) {
   return <span className={DIETARY_TAG_CLASSES}>{label}</span>
 }

--- a/src/components/drawer-with-tooltip.tsx
+++ b/src/components/drawer-with-tooltip.tsx
@@ -2,6 +2,7 @@ import { Tooltip } from '@base-ui/react/tooltip'
 import { Drawer } from 'vaul'
 import { NavTooltipBody } from './nav-tooltip'
 
+/** Combines a Drawer trigger with a Tooltip */
 export function DrawerWithTooltip() {
   return (
     <Tooltip.Provider>

--- a/src/components/empty-cell.tsx
+++ b/src/components/empty-cell.tsx
@@ -1,6 +1,7 @@
 import { cn } from '../helpers/dom'
 import { SrOnly } from './sr-only'
 
+/** Placeholder shown in a table cell when there's no value */
 export function EmptyCell({
   label = 'None',
   className,

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -13,6 +13,7 @@ type State = {
   error?: Error
 }
 
+/** Catches render errors in its subtree and displays a fallback UI */
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props)

--- a/src/components/form-combobox.tsx
+++ b/src/components/form-combobox.tsx
@@ -12,6 +12,7 @@ type FormComboboxProps = {
   placeholder?: string
 }
 
+/** Multi-select combobox input with removable chips */
 export function FormCombobox({ options, value, onValueChange, placeholder }: FormComboboxProps) {
   const anchorRef = React.useRef<HTMLDivElement>(null)
 

--- a/src/components/form-control.tsx
+++ b/src/components/form-control.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { cn } from '../helpers/dom'
 
+/** Vertical wrapper grouping a form label and its input */
 export function FormControl({ className, ...props }: React.ComponentProps<'div'>) {
   return <div className={cn('w-full flex gap-1 flex-col', className)} {...props} />
 }

--- a/src/components/form-input.tsx
+++ b/src/components/form-input.tsx
@@ -3,6 +3,7 @@ import { cn } from '../helpers/dom'
 
 export type FormInputProps = React.ComponentProps<'input'>
 
+/** Styled text input for forms */
 export const FormInput = React.forwardRef<HTMLInputElement, FormInputProps>(
   ({ className, ...props }, ref) => {
     return (

--- a/src/components/form-label.tsx
+++ b/src/components/form-label.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { cn } from '../helpers/dom'
 
+/** Styled label for a form field */
 export function FormLabel({ className, ...props }: React.ComponentProps<'label'>) {
   return (
     <label

--- a/src/components/form-select.tsx
+++ b/src/components/form-select.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown } from 'lucide-react'
 import { cn } from '../helpers/dom'
 
+/** Styled select input with a dropdown indicator */
 export function FormSelect({ className, children, ...props }: React.ComponentProps<'select'>) {
   return (
     <div className={cn('relative h-10', props.disabled === true ? 'grayscale' : '', className)}>

--- a/src/components/form-textarea.tsx
+++ b/src/components/form-textarea.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { cn } from '../helpers/dom'
 
+/** Styled multi-line text input for forms */
 export function FormTextarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
     <textarea

--- a/src/components/nav-actions.tsx
+++ b/src/components/nav-actions.tsx
@@ -3,6 +3,7 @@ import { Button } from './button'
 
 export const NAV_ICON_SIZE = 16
 
+/** Icon button styled for use in the nav bar */
 export function NavButton({ className, ...props }: React.ComponentProps<typeof Button>) {
   return (
     <Button

--- a/src/components/nav-search.tsx
+++ b/src/components/nav-search.tsx
@@ -20,6 +20,7 @@ const FormSchema = z.object({
   s: z.string(),
 })
 
+/** Nav bar button that opens a drawer for searching recipes */
 export function NavSearch() {
   const [open, setOpen] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)

--- a/src/components/nav-tooltip.tsx
+++ b/src/components/nav-tooltip.tsx
@@ -1,9 +1,11 @@
 import { Tooltip } from '@base-ui/react/tooltip'
 
+/** Root wrapper for a nav bar tooltip */
 export function NavTooltip({ children }: { children: React.ReactNode }) {
   return <Tooltip.Root>{children}</Tooltip.Root>
 }
 
+/** Trigger element for a nav bar tooltip */
 export function NavTooltipTrigger({
   as,
 }: {
@@ -14,6 +16,7 @@ export function NavTooltipTrigger({
   )
 }
 
+/** Popup content for a nav bar tooltip */
 export function NavTooltipBody({ children }: { children: React.ReactNode }) {
   return (
     <Tooltip.Portal>

--- a/src/components/page-actions.tsx
+++ b/src/components/page-actions.tsx
@@ -14,6 +14,7 @@ export function PageActions({ className, ...props }: React.ComponentProps<'div'>
   return <div className={cn('flex items-end justify-between gap-2 w-full', className)} {...props} />
 }
 
+/** Link styled as a button for navigating back to a previous page */
 export function PageBackLink({
   className,
   children,
@@ -31,6 +32,7 @@ export function PageBackLink({
   )
 }
 
+/** Link styled as a button for navigating to an edit page */
 export function PageEditLink({
   className,
   children,
@@ -48,6 +50,7 @@ export function PageEditLink({
   )
 }
 
+/** Button styled for a destructive delete action */
 export function PageDeleteButton({
   className,
   children,

--- a/src/components/page-body.tsx
+++ b/src/components/page-body.tsx
@@ -1,6 +1,7 @@
 import { Container } from './container'
 import { cn } from '../helpers/dom'
 
+/** Wraps main page content in the site's card-style container */
 export function PageBody({
   children,
   className,

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,6 +1,7 @@
 import { Container } from './container'
 import { Stack } from './stack'
 
+/** Page header section with a decorative gradient background */
 export function PageHeader({ children }: { children: React.ReactNode }) {
   return (
     <div className="pb-6 pt-14 md:pb-20 md:pt-14 relative overflow-hidden bg-indigo-50 dark:bg-zinc-900">

--- a/src/components/page-heading.tsx
+++ b/src/components/page-heading.tsx
@@ -1,5 +1,6 @@
 import { cn } from '../helpers/dom'
 
+/** Styled h1 heading for a page */
 export function PageHeading({ className, ...props }: React.ComponentProps<'h1'>) {
   return (
     <h1

--- a/src/components/recipe-table-skeleton.tsx
+++ b/src/components/recipe-table-skeleton.tsx
@@ -2,6 +2,7 @@ type RecipeTableSkeletonProps = {
   showDietaryPref?: boolean
 }
 
+/** Loading placeholder row for the recipes table */
 export function RecipeTableSkeleton({ showDietaryPref = true }: RecipeTableSkeletonProps) {
   return (
     <tr className="border-b border-slate-200 dark:border-zinc-800 animate-pulse">

--- a/src/components/sr-only.tsx
+++ b/src/components/sr-only.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 
+/** Visually hides children while keeping them available to screen readers */
 export function SrOnly({ children }: { children: React.ReactNode }) {
   return <div className="sr-only">{children}</div>
 }

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { cn } from '../helpers/dom'
 import { Switch as BaseSwitch } from '@base-ui/react/switch'
 
+/** Styled toggle switch */
 export function Switch({
   defaultChecked,
   className,

--- a/src/components/tag.tsx
+++ b/src/components/tag.tsx
@@ -31,6 +31,7 @@ const tagClasses = cva(
   },
 )
 
+/** Small colored label for tagging content */
 export function Tag({
   children,
   className,


### PR DESCRIPTION
## Summary
- Adds the JSDoc-comment requirement for global components to CLAUDE.md's coding preferences (the standard #58 referenced didn't actually exist yet).
- Adds a short one-line JSDoc comment to every exported component in `src/components/` that was missing one.

## Test plan
- [x] `npm run qa` (lint, type-check, tests, build) passes

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)