### PR TITLE
Improve CategoryLink hover state

### DIFF
--- a/src/components/__tests__/category-link.test.tsx
+++ b/src/components/__tests__/category-link.test.tsx
@@ -23,25 +23,32 @@ describe('CategoryLink', () => {
     expect(link).toHaveClass(
       'h-42',
       'w-full',
+      'inline-flex',
       'justify-center',
       'items-center',
-      'bg-gradient-to-b',
-      'to-white',
-      'from-white',
-      'hover:from-white',
-      'hover:to-indigo-50',
-      'text-indigo-500',
-      'shadow-lg',
-      'shadow-indigo-100/50',
-      'border',
-      'border-indigo-200',
-      'focus-visible:inset-ring-4',
-      'inset-ring-indigo-700',
-      'inline-flex',
       'rounded-4xl',
       'font-semibold',
+      'bg-gradient-to-b',
+      'border',
+      'shadow-lg',
       'transition',
     )
+  })
+
+  // Asserted by variant prefix rather than exact color so restyling does not
+  // break the test. The intent is that each state has *some* styling.
+  it('styles hover, focus, and active states', () => {
+    render(<CategoryLink to="/recipes">Category</CategoryLink>)
+    const link = screen.getByText('Category')
+    expect(link.className).toMatch(/(?<!:)hover:/)
+    expect(link.className).toMatch(/focus-visible:/)
+    expect(link.className).toMatch(/(?<!:)active:/)
+  })
+
+  it('respects reduced motion for the hover lift', () => {
+    render(<CategoryLink to="/recipes">Category</CategoryLink>)
+    const link = screen.getByText('Category')
+    expect(link).toHaveClass('motion-safe:hover:-translate-y-0.5')
   })
 
   it('accepts custom className', () => {

--- a/src/components/category-link.tsx
+++ b/src/components/category-link.tsx
@@ -6,7 +6,23 @@ export function CategoryLink({ className, ...props }: { className?: string } & L
   return (
     <Link
       className={cn(
-        'h-42 w-full justify-center items-center bg-gradient-to-b to-white from-white hover:from-white hover:to-indigo-50 dark:to-zinc-800 dark:from-zinc-800 dark:hover:from-zinc-800 dark:hover:to-zinc-700 text-indigo-500 dark:text-indigo-400 shadow-lg shadow-indigo-100/50 dark:shadow-zinc-950/30 border border-indigo-200 dark:border-zinc-700 focus-visible:inset-ring-4 inset-ring-indigo-700 dark:inset-ring-indigo-500 inline-flex rounded-4xl font-semibold transition',
+        [
+          'h-42 w-full inline-flex justify-center items-center rounded-4xl font-semibold',
+          'bg-gradient-to-b from-white to-white dark:from-zinc-800 dark:to-zinc-800',
+          'text-indigo-500 dark:text-indigo-400',
+          'border border-indigo-200 dark:border-zinc-700',
+          'shadow-lg shadow-indigo-100/50 dark:shadow-zinc-950/30',
+          // Hover and keyboard focus share one surface treatment so both inputs
+          // get the same affordance
+          'hover:from-white hover:to-indigo-50 hover:border-indigo-300 hover:shadow-xl hover:shadow-indigo-200/60',
+          'dark:hover:from-zinc-800 dark:hover:to-zinc-700 dark:hover:border-zinc-600 dark:hover:shadow-zinc-950/50',
+          'focus-visible:to-indigo-50 focus-visible:border-indigo-300',
+          'dark:focus-visible:to-zinc-700 dark:focus-visible:border-zinc-600',
+          'motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0',
+          'active:to-indigo-100 active:shadow-md dark:active:to-zinc-600',
+          'focus:outline-0 focus-visible:inset-ring-4 inset-ring-indigo-700 dark:inset-ring-indigo-500',
+          'transition duration-200 ease-out',
+        ],
         className,
       )}
       {...props}


### PR DESCRIPTION
## What

The hover state on `CategoryLink` changed only the bottom gradient stop, `white` → `indigo-50`. Two problems with that:

- It was a small color change carrying the entire hover affordance.
- The gradient runs top to bottom, so the top of the card did not change at all. The emoji and label are vertically centered, meaning the strongest part of the effect landed below where the eye actually is.

## Changes

Hover now layers several signals rather than relying on one:

- Border shifts to `indigo-300`
- Shadow grows to `shadow-xl` with an indigo tint
- Card lifts 2px, guarded by `motion-safe`
- Press state is distinct — the lift cancels and the tint deepens one step
- `focus-visible` shares the same surface treatment, so keyboard users get the same affordance as mouse users

The gradient tint itself stays at `indigo-50`. It was too weak before only because it was the sole signal; now that the border, shadow, and lift carry the work, it reads as an accent.

Also adds `focus:outline-0`. Without it, keyboard focus drew the browser default outline on top of the existing 4px inset ring — two competing rings.

## Ladder

| State | Light | Dark |
|---|---|---|
| Rest | `white` | `zinc-800` |
| Hover / focus-visible | `indigo-50` | `zinc-700` |
| Active | `indigo-100` | `zinc-600` |

## Test

The existing test asserted the exact class list, so it broke on any restyle. It now checks structural classes, and checks interaction states by variant prefix rather than exact color. Added a test pinning the reduced-motion guard.

## Verification

- `npm run qa` passes: lint, type-check, 98 tests, build
- Confirmed in the built CSS that `active:` rules are emitted after `hover:` rules, so the press state correctly cancels the lift. Tailwind sorts variants itself, so source order does not decide this.

## Not covered

Reviewed in the browser by the author, but there are no automated visual checks for the hover appearance.