### PR TITLE
Group QA output by command

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
-    "qa": "concurrently \"npm run lint\" \"npm run type-check\" \"npm run test\" \"npm run build\""
+    "qa": "concurrently --group --names lint,types,test,build \"npm run lint\" \"npm run type-check\" \"npm run test\" \"npm run build\""
   },
   "devDependencies": {
     "@tailwindcss/typography": "0.5.19",


### PR DESCRIPTION
`concurrently` interleaved all four QA commands, so vitest's file list got split across unrelated lint and build lines. Reading a CI log, it looked like test files were missing when they had actually run.

## The change

```diff
-"qa": "concurrently \"npm run lint\" \"npm run type-check\" \"npm run test\" \"npm run build\""
+"qa": "concurrently --group --names lint,types,test,build \"npm run lint\" \"npm run type-check\" \"npm run test\" \"npm run build\""
```

- `--group` buffers each command and prints it as one contiguous block, in declared order.
- `--names` replaces the `[0]`–`[3]` prefixes with `lint`, `types`, `test`, `build`.

The commands still run in parallel. Only the output is serialized.

## Trade-off

Output is no longer live. Nothing appears from `test` until `lint` and `types` have flushed. For a run this short it is a fair trade, but it is a real change in local feel.

## QA

`npm run qa` passes with the new flags: lint clean, type-check clean, 98 tests across 12 files, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)